### PR TITLE
Improve auto build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ source software which enables the use of this currency.
 
 For more information, as well as an immediately useable, binary version of
 the KZCash Core software, see http://kz.cash/.
+
+Quick Build Script
+------------------
+For a simple way to build KZCash Core on Debian or Ubuntu systems, run the
+`auto_build.sh` script located in the project root. This script installs common
+build dependencies (adding the `bitcoin/bitcoin` PPA automatically if
+Berkeley DB 4.8 packages are missing) and compiles the project:
+
+```bash
+./auto_build.sh
+```
+
+The script may require sudo access to install packages. After running it,
+the compiled binaries can be found in the `src` directory.

--- a/auto_build.sh
+++ b/auto_build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Simple build script for KZCash Core on Debian/Ubuntu systems.
+# This installs common dependencies and builds the project.
+
+set -e
+
+# Update package lists and install dependencies
+sudo apt-get update
+
+# Ensure Berkeley DB 4.8 packages are available. If not, add the Bitcoin PPA.
+if apt-cache policy libdb4.8-dev | grep -q "Candidate: (none)"; then
+    sudo apt-get install -y software-properties-common
+    sudo add-apt-repository -y ppa:bitcoin/bitcoin
+    sudo apt-get update
+fi
+
+sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config libssl-dev \
+    libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev \
+    libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+    libboost-thread-dev libdb4.8-dev libdb4.8++-dev libminiupnpc-dev \
+    libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev \
+    qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
+
+# Generate build scripts, configure and compile
+./autogen.sh
+./configure --with-gui=qt5
+make -j$(nproc)
+
+# Uncomment the next line to run the test suite
+# make check
+
+# Uncomment the next line to install
+# sudo make install


### PR DESCRIPTION
## Summary
- tweak auto_build.sh to add the `bitcoin/bitcoin` PPA when Berkeley DB packages are missing
- document the automatic PPA step in README

## Testing
- `bash -n auto_build.sh`
- `shellcheck auto_build.sh` *(fails: command not found)*
- `./auto_build.sh --version` *(fails: PPA not available for this release)*

------
https://chatgpt.com/codex/tasks/task_e_684ca189bba4832a8805204e2fc1ec6c